### PR TITLE
Replace Gulp JSDoc with plain JSDoc

### DIFF
--- a/model/patient.js
+++ b/model/patient.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - patient name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('patient',
         {

--- a/model/question-instance.js
+++ b/model/question-instance.js
@@ -7,13 +7,19 @@
 const Sequelize = require('sequelize');
 
 /**
- * Each Question-instance will have associated with it a patient_id and survey_instance
- * This will provide an overview of the answers submitted by the patient for
- * each question from that survey instance.
- * @typedef {Object} SurveyInstance
- * @property {String} name - SurveyInstance name
+ * Each QuestionInstance will have associated with it a Patient and SurveyInstance
+ * This will provide an overview of the answers submitted by the Patient for
+ * each question from that SurveyInstance.
+ * @typedef {Object} QuestionInstance
+ * @property {String} name - QuestionInstance name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('question_instance',
         {

--- a/model/question-type.js
+++ b/model/question-type.js
@@ -12,8 +12,14 @@ const Sequelize = require('sequelize');
  * @property {String} name - questionType name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
-    sequelize.define('question-type',
+    sequelize.define('question_type',
         {
             name: {
                 type: Sequelize.STRING

--- a/model/question.js
+++ b/model/question.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - question name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('question',
         {

--- a/model/schedule-type.js
+++ b/model/schedule-type.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - schedule name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('schedule_type',
         {

--- a/model/schedule.js
+++ b/model/schedule.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - schedule name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('schedule',
         {

--- a/model/survey-instance.js
+++ b/model/survey-instance.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - SurveyInstance name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('survey_instance',
         {

--- a/model/survey-template.js
+++ b/model/survey-template.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - survey template name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('survey_template',
         {

--- a/model/trial.js
+++ b/model/trial.js
@@ -12,6 +12,12 @@ const Sequelize = require('sequelize');
  * @property {String} name - trial name
  */
 
+/**
+ * Registers model with Sequelize
+ * @function register
+ * @param {Sequelize} sequelize - database instance
+ * @returns {Null} nothing
+ */
 module.exports = function (sequelize) {
     sequelize.define('trial',
         {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Pain Reporting Portal",
   "main": "index.js",
+  "scripts": {
+    "documentation": "jsdoc model presenter task --recurse --destination documentation"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ser515asu/PRP-Manhattan-Project.git"
@@ -21,10 +24,11 @@
   "dependencies": {
     "gulp": "gulpjs/gulp#4.0",
     "gulp-eslint": "^1.0.0",
-    "gulp-jsdoc": "^0.1.5",
     "handlebars": "^4.0.3",
     "hapi": "^10.1.0",
+    "jsdoc": "^3.3.3",
     "mysql": "^2.9.0",
+    "npm": "^3.3.5",
     "pm2": "^0.15.7",
     "read": "^1.0.7",
     "sequelize": "^3.10.0",

--- a/task/doc.js
+++ b/task/doc.js
@@ -4,18 +4,27 @@
  * @module task/doc
  */
 
-const gulp = require('gulp');
-const jsdoc = require('gulp-jsdoc');
+const npm = require('npm');
+const npmPackage = require('../package.json');
 
 /**
  * Turns documentation comments into viewable wep pages.
  * @function doc
- * @returns {Pipe} Gulp Pipeline
+ * @param {Function} done - completion callback
+ * @returns {Null} nothing
  */
-function doc () {
-    return gulp
-        .src(['model/*.js', 'presenter/*.js', 'task/*.js'])
-        .pipe(jsdoc('./documentation'));
+function doc (done) {
+    npm.load(npmPackage, function (err) {
+        if (err) {
+            console.log(err);
+        }
+        npm.commands.runScript(['documentation'], function (err) {
+            if (err) {
+                console.log(err);
+            }
+            done();
+        });
+    });
 }
 
 doc.description = 'Turns documentation comments into viewable wep pages.';

--- a/task/test.js
+++ b/task/test.js
@@ -9,7 +9,7 @@ const eslint = require('gulp-eslint');
 
 /**
  * Checks that the Javascript code is valid.
- * @returns {Pipe} Gulp Pipeline
+ * @returns {Null} nothing
  */
 function test () {
     return gulp.src(['*.js', 'model/**/*.js', 'presenter/**/*.js', 'task/**/*.js'])


### PR DESCRIPTION
**Commit Overview**
* Replace Gulp JSDoc with plain JSDoc
* Gulp JSDoc appears to be rather outdated and is not generating the `typedef` documentation for the database models correctly. Plain JSDoc does not have this issue.
* update documentation throughout project to be more complete and accurate.