### PR TITLE
Target patient count and duration update on UI

### DIFF
--- a/presenter/dashboard.js
+++ b/presenter/dashboard.js
@@ -87,7 +87,7 @@ function processTrial (currentTrial) {
     const statuses = ['Pending', 'Upcoming', 'In Progress', 'Completed'];
     const status = statuses[Math.floor(Math.random() * 4)];
     // TODO: Currently fake data, make this live data
-    const targetCount = Math.floor(Math.random() * 900 + 500);
+    const targetCount = moment(trial.targetCount);
     const recruitedCount = targetCount - 153;
     const activeCount = recruitedCount - 23;
     const compliantCount = activeCount - 67;

--- a/presenter/dashboard.js
+++ b/presenter/dashboard.js
@@ -86,8 +86,8 @@ function processTrial (currentTrial) {
     const endDate = moment(trial.endAt);
     const statuses = ['Pending', 'Upcoming', 'In Progress', 'Completed'];
     const status = statuses[Math.floor(Math.random() * 4)];
+    const targetCount = trial.targetCount;
     // TODO: Currently fake data, make this live data
-    const targetCount = moment(trial.targetCount);
     const recruitedCount = targetCount - 153;
     const activeCount = recruitedCount - 23;
     const compliantCount = activeCount - 67;

--- a/presenter/trial.js
+++ b/presenter/trial.js
@@ -80,7 +80,6 @@ function processTrial (currentTrial) {
         duration: startDate.to(endDate, true),
         patientCount: Math.floor(Math.random() * 900 + 100),
         noncompliantCount: Math.floor(Math.random() * 100),
-        targetNumberOfPatients: Math.floor(Math.random() * 150),
         recruitedNumberOfPatients: Math.floor(Math.random() * 200),
         activePatients: Math.floor(Math.random() * 50),
         completedPatients: Math.floor(Math.random() * 40),

--- a/view/template/trial.hbs
+++ b/view/template/trial.hbs
@@ -47,14 +47,6 @@
                         </tr>
                         <tr>
                             <th scope="row">
-                                Duration
-                            </th>
-                            <td>
-                                {{ trial.duration }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">
                                 Patient Count
                             </th>
                             <td>


### PR DESCRIPTION
User can now add a new trial and the target number of patients will reflect their user input and be displayed on the dashboard
Removed duration from description
Removed target number of patients random number calculation