### PR TITLE
Style Fixes

### DIFF
--- a/view/layout/default.hbs
+++ b/view/layout/default.hbs
@@ -12,7 +12,7 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
         <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
-        <script src="https://cdn.rawgit.com/nnnick/Chart.js/2.0.0-beta/Chart.min.js"></script>
+        <script src="https://cdn.rawgit.com/nnnick/Chart.js/2.0.0-alpha4/Chart.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/2.4.0/fullcalendar.min.js"></script>
 
         <!-- Polyfills -->

--- a/view/layout/default.hbs
+++ b/view/layout/default.hbs
@@ -20,17 +20,25 @@
         <script src="https://cdn.rawgit.com/chemerisuk/better-i18n-plugin/v1.0.3/dist/better-i18n-plugin.js"></script>
         <script src="https://cdn.rawgit.com/chemerisuk/better-dateinput-polyfill/v1.5.2/dist/better-dateinput-polyfill.js"></script>
         <style>
-            #successFailProgress::-webkit-progress-bar {
-              background-color: #d9534f;
+            .progress-good-and-bad {
+                color: #d9534f;
+                background: #d9534f;
             }
-            #successFailProgress::-webkit-progress-value {
-              background-color: #5cb85c;
+
+            .progress-good-and-bad::-webkit-progress-bar {
+                background: #d9534f !important;
             }
-            #doneUndoneProgress::-webkit-progress-bar {
-              background-color: #ccc;
+
+            .progress-good-and-bad::-webkit-progress-value {
+                background-color: #5cb85c !important;
             }
-            #doneUndoneProgress::-webkit-progress-value {
-              background-color: #0275d8;
+
+            .progress-good-and-bad::-moz-progress-bar {
+                background-color: #5cb85c;
+            }
+
+            .progress-good-and-bad > .progress-bar {
+                background-color: #5cb85c;
             }
         </style>
     </head>

--- a/view/template/dashboard.hbs
+++ b/view/template/dashboard.hbs
@@ -149,28 +149,28 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <progress id="successFailProgress" class="progress" value="{{ recruitedPercent }}" max="100">
-                                          <div class="progress">
-                                            <span class="progress-bar" style="width: {{ recruitedPercent }}%;">25%</span>
-                                          </div>
+                                        <progress class="progress progress-good-and-bad" value="{{ recruitedPercent }}" max="100">
+                                            <div class="progress">
+                                                <span class="progress-bar" style="width: {{ recruitedPercent }}%;">25%</span>
+                                            </div>
                                         </progress>
                                         {{ recruitedPercent }}% Recruited <br>
                                         {{ unrecruitedPercent }}% Unrecruited
                                     </td>
                                     <td>
-                                        <progress id="doneUndoneProgress" class="progress" value="{{ activePercent }}" max="100">
-                                          <div class="progress">
-                                            <span class="progress-bar" style="width: {{ activePercent }}%;">25%</span>
-                                          </div>
+                                        <progress class="progress" value="{{ activePercent }}" max="100">
+                                            <div class="progress">
+                                                <span class="progress-bar" style="width: {{ activePercent }}%;">25%</span>
+                                            </div>
                                         </progress>
                                         {{ activePercent }}% Active <br>
                                         {{ completedPercent }}% Completed
                                     </td>
                                     <td>
-                                        <progress id="successFailProgress" class="progress" value="{{ compliantPercent }}" max="100">
-                                          <div class="progress">
-                                            <span class="progress-bar" style="width: {{ compliantPercent }}%;">25%</span>
-                                          </div>
+                                        <progress class="progress progress-good-and-bad" value="{{ compliantPercent }}" max="100">
+                                            <div class="progress">
+                                                <span class="progress-bar" style="width: {{ compliantPercent }}%;">25%</span>
+                                            </div>
                                         </progress>
                                         {{ compliantPercent }}% Compliant <br>
                                         {{ noncompliantPercent }}% Noncompliant

--- a/view/template/dashboard.hbs
+++ b/view/template/dashboard.hbs
@@ -194,7 +194,8 @@
     var options = {
         legendTemplate: '<ul class="list-group list-group-flush"><% for (var i = 0; i < data.datasets.length; i++){%><li class="list-group-item"><i style="color:<%=data.datasets[i].backgroundColor%>" class="fa fa-circle"></i> <%=data.datasets[i].label%></li><%}%></ul>'
     };
-    var radarChart = new Chart.Radar(ctx, {
+    var radarChart = new Chart(ctx, {
+        type: 'radar',
         data: data,
         options: options
     });

--- a/view/template/patient.hbs
+++ b/view/template/patient.hbs
@@ -105,7 +105,6 @@
                 ]
             },
             options: {
-                responsive: true,
                 scales: {
                     xAxes: [
                         {

--- a/view/template/trial.hbs
+++ b/view/template/trial.hbs
@@ -181,7 +181,8 @@
     var options = {
         legendTemplate: '<ul class="list-group list-group-flush"><% for (var i = 0; i < data.labels.length; i++){%><li class="list-group-item"><i style="color:<%=data.datasets[0].backgroundColor[i]%>" class="fa fa-circle"></i> <%=data.labels[i]%></li><%}%></ul>'
     };
-    var myNewChart = new Chart.Doughnut(ctx, {
+    var myNewChart = new Chart(ctx, {
+        type: 'doughnut',
         data: data,
         options: options
     });


### PR DESCRIPTION
**Commit Overview**
* Revert Chart JS to Alpha 4 until there is a fix for tool tips.
* All charts now directly call the `Chart` object and pass in a `type` parameter.
* Update `progress-good-and-bad` to support Chrome and Firefox.