### PR TITLE
Cleanup Lint Rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -77,7 +77,7 @@ rules:
     no-iterator: 2
     no-labels: 2
     no-lone-blocks: 2
-    no-loop-func: 2
+    no-loop-func: 0 # no-var
     no-magic-numbers: 2
     no-multi-spaces: 2
     no-multi-str: 2
@@ -172,8 +172,7 @@ rules:
         - 120
     max-nested-callbacks:
         - 2
-        - 1
-    max-nested-callbacks: 2
+        - 2
     max-params: 2
     max-statements: 2
     new-cap: 2

--- a/api/handler/.eslintrc.yml
+++ b/api/handler/.eslintrc.yml
@@ -1,2 +1,0 @@
-rules:
-    no-loop-func: 0

--- a/api/helper/.eslintrc.yml
+++ b/api/helper/.eslintrc.yml
@@ -1,2 +1,0 @@
-rules:
-    no-loop-func: 0

--- a/api/test/.eslintrc.yml
+++ b/api/test/.eslintrc.yml
@@ -3,5 +3,4 @@ rules:
     id-length:
         - 2
         - exceptions:
-            - _
             - t

--- a/controller/test/.eslintrc.yml
+++ b/controller/test/.eslintrc.yml
@@ -3,5 +3,4 @@ rules:
     id-length:
         - 2
         - exceptions:
-            - _
             - t

--- a/rule/test/.eslintrc.yml
+++ b/rule/test/.eslintrc.yml
@@ -3,5 +3,4 @@ rules:
     id-length:
         - 2
         - exceptions:
-            - _
             - t

--- a/task/.eslintrc.yml
+++ b/task/.eslintrc.yml
@@ -1,5 +1,2 @@
 rules:
     global-require: 0
-    max-nested-callbacks:
-        - 2
-        - 2

--- a/view/.eslintrc.yml
+++ b/view/.eslintrc.yml
@@ -20,6 +20,7 @@ rules:
     vars-on-top: 2
     new-cap: 0
     no-invalid-this: 0
+    no-loop-func: 2
     no-new: 0
 
     # Strict Mode


### PR DESCRIPTION
* `no-loop-func` is now allowed because the problem only affects `var` which is banned.
* Remaining `lodash` exceptions removed
* Increase `max-callbacks` to 2 since that is common throughout the project